### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ionit (0.3.5-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 18:19:21 +0000
+
 ionit (0.3.5-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ ionit (0.3.5-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 18:19:21 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: debhelper-compat (= 12),
                python3-jinja2,
                python3-setuptools,
                python3-yaml | python3-ruamel.yaml
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Homepage: https://github.com/bdrung/ionit
 Rules-Requires-Root: no
 Vcs-Browser: https://github.com/bdrung/ionit

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/bdrung/ionit/issues
+Bug-Submit: https://github.com/bdrung/ionit/issues/new
+Repository: https://github.com/bdrung/ionit.git
+Repository-Browse: https://github.com/bdrung/ionit


### PR DESCRIPTION
Fix some issues reported by lintian
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/ionit/ea3f1556-8ec9-4d48-98a7-0c6fbb649f47.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/ea3f1556-8ec9-4d48-98a7-0c6fbb649f47/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/ea3f1556-8ec9-4d48-98a7-0c6fbb649f47/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/ea3f1556-8ec9-4d48-98a7-0c6fbb649f47/diffoscope)).
