### PR TITLE
ci: move upload to Codecov to separate job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
           - debian:testing-slim
           - debian:unstable-slim
           - ubuntu:focal
-          - ubuntu:hirsute
           - ubuntu:impish
           - ubuntu:jammy
         yaml_package:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
           - debian:testing-slim
           - debian:unstable-slim
           - ubuntu:focal
-          - ubuntu:impish
           - ubuntu:jammy
         yaml_package:
           - python3-ruamel.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,11 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
+      - name: Sanitize container name (for artifact name)
+        run: >
+          container=$(echo "${{ matrix.container }}" | sed 's/:/-/') &&
+          echo "JOB=${GITHUB_JOB}-${container}-${{ matrix.yaml_package }}"
+          >> "$GITHUB_ENV"
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: >
@@ -34,15 +39,11 @@ jobs:
         run: |
           python3 -m coverage run -m unittest discover -v
           python3 -m coverage xml
-      - name: Install dependencies for Codecov
-        run: >
-          apt-get install --no-install-recommends --yes
-          ca-certificates curl git
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
         with:
-          fail_ci_if_error: true
-          functionalities: gcov
+          name: coverage-${{ env.JOB }}
+          path: ./coverage*.xml
 
   # Debian buster needs pylint3 instead of pylint
   unittest-debian-buster:
@@ -79,3 +80,18 @@ jobs:
       - name: Run yamllint
         run: |
           yamllint .
+
+  upload-to-codecov:
+    if: ${{ always() }}
+    needs:
+      - unittest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
Uploading the code coverage result to Codecov might fail. Then the whole tests needs to be restarted just to try the upload again.

Move uploading the code coverage results to the separate `upload-to-codecov` job. Store the coverage results of the test jobs as artifacts.